### PR TITLE
Ramp-up metric calculation

### DIFF
--- a/package_metrics_cli/src/api/getReadme
+++ b/package_metrics_cli/src/api/getReadme
@@ -1,0 +1,16 @@
+import { Octokit } from "@octokit/core";
+
+export async function getReadme(owner: string, repo: string) {
+    const octokit = new Octokit();
+    try {
+        const response = await octokit.request('GET /repos/{owner}/{repo}/readme', {
+            accept: 'application/vnd.github+json',
+            owner: owner,
+            repo: repo,
+        });
+        return response;
+    } catch (error) {
+        console.error(error);
+        return error;
+    }
+}

--- a/package_metrics_cli/src/api/types.ts
+++ b/package_metrics_cli/src/api/types.ts
@@ -1,0 +1,5 @@
+import { Endpoints } from "@octokit/types";
+
+export type communityProfileResponse = Endpoints["GET /repos/{owner}/{repo}/community/profile"]["response"];
+
+export type readmeResponse = Endpoints["GET /repos/{owner}/{repo}/readme"]["response"];

--- a/package_metrics_cli/src/metrics/rampUp.ts
+++ b/package_metrics_cli/src/metrics/rampUp.ts
@@ -1,0 +1,19 @@
+import { communityProfileResponse, readmeResponse } from "../api/types";
+
+export async function calculateRampUp(profile: communityProfileResponse, readme: readmeResponse) {
+    if (profile.data.documentation) {
+        //full score if there is a docs site
+        return 1;
+    } else if (profile.data.files.readme && readme.data.size > 100) {
+        if (readme.data.size > 500) {
+            //small readme
+            return 0.25
+        } else if (readme.data.size > 2500) {
+            //medium readme
+            return 0.5
+        } else if (readme.data.size > 10000) {
+            //large readme
+            return 0.75
+        }
+    }
+}


### PR DESCRIPTION
Calculate the ramp-up metric based on data returned by the community profile and get readme api calls.

I added a wrapper for the REST api call that returns the readme of a project. I also added file to export the types for the various responses of the api calls that we are using.