### PR TITLE
fixed community metric bug

### DIFF
--- a/SMALL_URL_FILE.txt
+++ b/SMALL_URL_FILE.txt
@@ -1,3 +1,1 @@
-https://github.com/lodash/lodash
-https://www.npmjs.com/package/File
-https://www.npmjs.com/package/browserify
+https://github.com/davisjam/safe-regex

--- a/package_metrics_cli/src/api/getCommits.ts
+++ b/package_metrics_cli/src/api/getCommits.ts
@@ -11,7 +11,7 @@ export async function getCommits(owner: string, repo: string) : Promise<commitsR
         });
         return response;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getCommunityProfile.ts
+++ b/package_metrics_cli/src/api/getCommunityProfile.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/core";
 import { communityProfileResponse } from "./types";
 
-export async function getCommunityProfile(owner: string, repo: string) : Promise<communityProfileResponse> {
+export async function getCommunityProfile(owner: string, repo: string): Promise<communityProfileResponse | null> {
     const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
     try {
         const profile = await octokit.request('GET /repos/{owner}/{repo}/community/profile', {
@@ -9,8 +9,14 @@ export async function getCommunityProfile(owner: string, repo: string) : Promise
             repo,
         });
         return profile;
-    } catch (error) {
-        console.error(error);
+    } catch (error: any) {
+        // if the error is a 404, return null
+        if (error.status === 404) {
+            console.log(`404 error for ${owner}/${repo}`);
+            return null;
+        }
+        console.log('non-404 error');
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getContributors.ts
+++ b/package_metrics_cli/src/api/getContributors.ts
@@ -11,7 +11,7 @@ export async function getContributors(owner: string, repo: string): Promise<cont
         });
         return response;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getIssues.ts
+++ b/package_metrics_cli/src/api/getIssues.ts
@@ -11,7 +11,7 @@ export async function getIssues(owner: string, repo: string) : Promise<issuesRes
         });
         return response;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getLicense.ts
+++ b/package_metrics_cli/src/api/getLicense.ts
@@ -23,7 +23,7 @@ export async function getLicense(owner: string, repo: string) : Promise<any> {
         );          
         return response;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getPkg.ts
+++ b/package_metrics_cli/src/api/getPkg.ts
@@ -10,7 +10,7 @@ export async function getPkg(name: string, version: string): Promise<pkgResponse
         const json = await response.json();
         return json;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/api/getReadme.ts
+++ b/package_metrics_cli/src/api/getReadme.ts
@@ -10,7 +10,7 @@ export async function getReadme(owner: string, repo: string) : Promise<any> {
         });
         return response;
     } catch (error) {
-        console.error(error);
+        // console.error(error);
         throw error;
     }
 }

--- a/package_metrics_cli/src/metrics/rampUp.ts
+++ b/package_metrics_cli/src/metrics/rampUp.ts
@@ -5,16 +5,16 @@ import { logToFile } from "../logging/logging";
 // if there is a documentation site, then the metric returns 1 (maximum score)
 // the score is then proportial to the size of the readme, with a maximum score of 0.75
 // and a minimum score of 0 if there is no or very small readme
-export function calculateRampUp(profile: communityProfileResponse, readme: readmeResponse) : number {
+export function calculateRampUp(profile: communityProfileResponse | null, readme: readmeResponse) : number {
     
-    logToFile(!!profile.data.documentation, 2, "documentation exists");
+    logToFile(!!profile?.data.documentation, 2, "documentation exists");
     logToFile(readme.data.size, 2, "readme size")
     
-    if (profile.data.documentation) {
+    if (profile?.data.documentation) {
         //full score if there is a docs site
         logToFile(1, 1, "Ramp Up");
         return 1;
-    } else if (profile.data.files.readme) {
+    } else if (profile?.data.files.readme) {
         if (readme.data.size > 5000) {
             // large readme
             logToFile(0.75, 1, "Ramp Up");


### PR DESCRIPTION
The problem seems to have been caused by the repo being a fork or for some other reason the github API community/profile endpoint doesn't exist for certain repositories, ex: https://github.com/davisjam/safe-regex

The fix involved catching 404 errors and adjusting the ramp up metric to be able to handle a null input for community profile response.